### PR TITLE
fix: bump chart version

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: sloth
 description: Base chart for Sloth.
 type: application
-home: https://github.com/slok/sloth
+home: https://github.com/linode-obs/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.7.0
+version: 0.8.0


### PR DESCRIPTION
forgot to bump the chart version when releasing v0.13.0