### PR TITLE
feat: v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [v0.13.0] - 2024-10-30
 
 - Custom labels for `sloth_slo_info{}` metric [#4](https://github.com/linode-obs/sloth/pull/4)
+- Bump Helm Chart version
 
 ## [v0.12.0] - 2023-07-03
 

--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: sloth
 description: Base chart for Sloth.
 type: application
-home: https://github.com/slok/sloth
+home: https://github.com/linode-obs/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.7.0
+version: 0.8.0


### PR DESCRIPTION
Releases v0.13.0
- Adds support for custom info labels in `sloth_slo_info{}` metrics #4 
- Bumps Helm chart version

To cut a release, you have to tag the branch:
```bash
git tag -a v0.13.0 -m "Release v0.13.0"; git push origin
```