### PR TITLE
test: disable buildvcs

### DIFF
--- a/scripts/build/bin/build-raw.sh
+++ b/scripts/build/bin/build-raw.sh
@@ -21,4 +21,4 @@ f_ver="-X ${version_path}=${VERSION:-dev}"
 
 # Build binary.
 echo "[*] Building binary at ${final_out} (GOOS=${GOOS:-}, GOARCH=${GOARCH:-}, GOARM=${GOARM:-}, VERSION=${VERSION:-}, EXTENSION=${EXTENSION:-})"
-CGO_ENABLED=0 go build -o ${final_out} --ldflags "${ldf_cmp} ${f_ver}"  ${src}
+CGO_ENABLED=0 go build -buildvcs=false -o ${final_out} --ldflags "${ldf_cmp} ${f_ver}"  ${src}


### PR DESCRIPTION
```
#21 exporting to image
#21 exporting layers
#21 exporting layers 11.8s done
#21 writing image sha256:f422bf0322ce6e1c56659ab533a1c925c681af71aeb28630acc865038df5e853 done
#21 naming to docker.io/local/sloth-dev:latest done
#21 DONE 11.9s
[+] Build OS type selected: Linux
[*] Building binary at ./bin/sloth-linux-amd64 (GOOS=linux, GOARCH=amd64, GOARM=, VERSION=v0.13.0, EXTENSION=-linux-amd64)
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

just want to test to see if the build passes