### PR TITLE
chore: bump version

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/linode-obs/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.8.0
+version: 0.8.1


### PR DESCRIPTION
chart won't build because the version hasn't changed from when we built it yesterday but then deleted the release