### PR TITLE
fix: add InfoLabels to PrometheusServiceLevelSpec

### DIFF
--- a/pkg/kubernetes/api/sloth/v1/types.go
+++ b/pkg/kubernetes/api/sloth/v1/types.go
@@ -38,6 +38,9 @@ type PrometheusServiceLevelSpec struct {
 	// and alerting rules generated for the service SLOs.
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// InfoLabels are labels appended to the `sloth_slo_info` metric
+	InfoLabels map[string]string `json:infoLabels,omitempty`
+
 	// +kubebuilder:validation:MinItems=1
 	//
 	// SLOs are the SLOs of the service.


### PR DESCRIPTION
Need to have InfoLabels in PrometheusServiceLevelSpec as well:
```
Failed to compare desired state to live state: failed to calculate diff: error calculating structured merge diff: error building typed value from config resource: errors: .spec.slos[0].infoLabels: field not declared in schema .spec.slos[1].infoLabels: field not declared in schema .spec.slos[2].infoLabels: field not declared in schema .spec.slos[3].infoLabels: field not declared in schema .spec.slos[4].infoLabels: field not declared in schema .spec.slos[5].infoLabels: field not declared in schema .spec.slos[6].infoLabels: field not declared in schema .spec.slos[7].infoLabels: field not declared in schema .spec.slos[8].infoLabels: field not declared in schema .spec.slos[9].infoLabels: field not declared in schema
```